### PR TITLE
fixed broken page source links

### DIFF
--- a/src/main/webapp/jumbotron.xhtml
+++ b/src/main/webapp/jumbotron.xhtml
@@ -42,7 +42,7 @@
                    Use it as a starting point to create something more unique.
                 </p>
                 <p>
-                    <a href="https://github.com/TheCoder4eu/BootsFacesWeb/blob/master/src/main/webapp/examples/jumbotron.xhtml" class="btn btn-lg btn-info">View Page Source »</a>
+                    <a href="https://github.com/TheCoder4eu/BootsFaces-examples/blob/master/src/main/webapp/jumbotron.xhtml" class="btn btn-lg btn-info">View Page Source »</a>
                 </p>
             </b:container>
 

--- a/src/main/webapp/starter_template.xhtml
+++ b/src/main/webapp/starter_template.xhtml
@@ -21,7 +21,7 @@
                 <p> Use this JSF document as a way to quickly start any new project.</p>
                 <p> All you get is this text and a mostly barebone JSF document.</p>
                 <p>
-                    <a href="https://github.com/TheCoder4eu/BootsFacesWeb/blob/master/src/main/webapp/examples/starter_template.xhtml" class="btn btn-lg btn-info">View Page Source »</a>
+                    <a href="https://github.com/TheCoder4eu/BootsFaces-examples/blob/master/src/main/webapp/starter_template.xhtml" class="btn btn-lg btn-info">View Page Source »</a>
                 </p>
             </b:jumbotron>
         </b:container>


### PR DESCRIPTION
As I stated in https://github.com/TheCoder4eu/BootsFacesWeb/issues/17, some links under http://showcase.bootsfaces.net/Examples/ are currently broken, because those examples where removed from the BootsFacesWeb project.
Turns out, it only were two links, but this should fix them again.
